### PR TITLE
Dumped predictor output to file. Resolves #44.

### DIFF
--- a/acton/acton.py
+++ b/acton/acton.py
@@ -13,7 +13,6 @@ import acton.proto.wrappers
 import acton.recommenders
 import astropy.io.ascii as io_ascii
 import astropy.table
-import matplotlib.pyplot as plt
 import numpy
 import sklearn.cross_validation
 import sklearn.linear_model

--- a/acton/acton.py
+++ b/acton/acton.py
@@ -1,8 +1,6 @@
 """Main processing script for Acton."""
 
 import logging
-import os.path
-import tempfile
 from typing import Iterable, List, TypeVar
 
 import acton.database
@@ -11,8 +9,6 @@ import acton.predictors
 import acton.proto.io
 import acton.proto.wrappers
 import acton.recommenders
-import astropy.io.ascii as io_ascii
-import astropy.table
 import numpy
 import sklearn.cross_validation
 import sklearn.linear_model

--- a/acton/cli.py
+++ b/acton/cli.py
@@ -75,7 +75,7 @@ def main(
         recommender: str,
         verbose: bool,
 ):
-    logging.warning('Not implemented: output, diversity,'
+    logging.warning('Not implemented: diversity, '
                     'recommendation_count, labeller_accuracy')
     logging.captureWarnings(True)
     if verbose:
@@ -84,6 +84,7 @@ def main(
         data_path=data,
         feature_cols=feature,
         label_col=label,
+        output_path=output,
         id_col=id,
         n_epochs=epochs,
         initial_count=initial_count,

--- a/acton/plot.py
+++ b/acton/plot.py
@@ -30,12 +30,13 @@ def plot(predictions: BinaryIO):
     with protobuf.DB() as db:
         accuracies = []
         for protobuf in acton.proto.io.read_protos(predictions, Predictions):
+            protobuf = acton.proto.wrappers.PredictorOutput(protobuf)
             ids = protobuf.ids
             predictions = protobuf.predictions
             assert predictions.shape[0] == 1
             predictions = predictions[0]
-            labels = db.read_labels(ids)
-            predicted_labels = predictions.round()
+            labels = db.read_labels([b'0'], ids).ravel()
+            predicted_labels = predictions.round().ravel()
             accuracies.append(sklearn.metrics.accuracy_score(
                 labels, predicted_labels))
 

--- a/acton/plot.py
+++ b/acton/plot.py
@@ -1,0 +1,49 @@
+"""Script to plot a dump of predictions."""
+
+import sys
+from typing.io import BinaryIO
+
+import acton.proto.io
+from acton.proto.predictors_pb2 import Predictions
+import acton.proto.wrappers
+import click
+import matplotlib.pyplot as plt
+import sklearn.metrics
+
+
+@click.command()
+@click.argument('predictions',
+                type=click.File('rb'),
+                required=True)
+def plot(predictions: BinaryIO):
+    """Plots predictions from a file.
+
+    Parameters
+    ----------
+    predictions
+        Predictions file.
+    """
+
+    # Read in the first protobuf to get the database file.
+    protobuf = next(acton.proto.io.read_protos(predictions, Predictions))
+    protobuf = acton.proto.wrappers.PredictorOutput(protobuf)
+    with protobuf.DB() as db:
+        accuracies = []
+        for protobuf in acton.proto.io.read_protos(predictions, Predictions):
+            ids = protobuf.ids
+            predictions = protobuf.predictions
+            assert predictions.shape[0] == 1
+            predictions = predictions[0]
+            labels = db.read_labels(ids)
+            predicted_labels = predictions.round()
+            accuracies.append(sklearn.metrics.accuracy_score(
+                labels, predicted_labels))
+
+        plt.plot(accuracies)
+        plt.xlabel('Number of additional labels')
+        plt.ylabel('Accuracy score')
+        plt.show()
+
+
+if __name__ == '__main__':
+    sys.exit(plot())

--- a/acton/proto/io.py
+++ b/acton/proto/io.py
@@ -1,5 +1,7 @@
 """Functions for reading/writing to protobufs."""
 
+import struct
+
 from google.protobuf.reflection import GeneratedProtocolMessageType
 import numpy
 
@@ -27,6 +29,64 @@ def read_proto(
         proto.ParseFromString(proto_file.read())
 
     return proto
+
+
+def write_protos(path: str):
+    """Serialises many protobufs to a file.
+    
+    Parameters
+    ----------
+    path
+        Path to binary file. Will be overwritten.
+
+    Notes
+    -----
+    Coroutine. Accepts protobufs, or None to terminate and close file.
+    """
+    with open(path, 'wb') as proto_file:
+        proto = yield
+        while proto:
+            proto = proto.SerializeToString()
+            # Protobufs are not self-delimiting, so we need to store the length
+            # of each protobuf that we write. We will do this with an unsigned
+            # long long (Q).
+            length = struct.pack('<Q', len(proto))
+            proto_file.write(length)
+            proto_file.write(proto)
+            proto = yield
+    while True:
+        proto = yield
+        if proto:
+            raise RuntimeError('Cannot write protobuf to closed file.')
+
+
+def read_protos(
+        path: str,
+        Proto: GeneratedProtocolMessageType
+) -> 'GeneratedProtocolMessageType()':
+    """Reads many protobufs from a file.
+
+    Parameters
+    ----------
+    path
+        Path to binary file.
+    Proto:
+        Protocol message class (from the generated protobuf module).
+
+    Yields
+    -------
+    GeneratedProtocolMessageType
+        A parsed protobuf.
+    """
+    # This is essentially the inverse of the write_protos function.
+    with open(path, 'rb') as proto_file:
+        length = proto_file.read(8)  # long long
+        while length:
+            length, = struct.unpack('<Q', length)
+            proto = Proto()
+            proto.ParseFromString(proto_file.read(length))
+            yield proto
+            length = proto_file.read(8)
 
 
 def get_ndarray(data: list, shape: tuple, dtype: str) -> numpy.ndarray:

--- a/acton/proto/io.py
+++ b/acton/proto/io.py
@@ -33,7 +33,7 @@ def read_proto(
 
 def write_protos(path: str):
     """Serialises many protobufs to a file.
-    
+
     Parameters
     ----------
     path

--- a/acton/proto/predictors.proto
+++ b/acton/proto/predictors.proto
@@ -3,6 +3,14 @@ syntax = "proto3";
 package acton.predictors;
 
 /**
+ * Key/value pair.
+ */
+message KeyVal {
+    string key = 1;
+    string value = 2;
+}
+
+/**
  * Input to predictors.
  */
 message Labels {
@@ -79,4 +87,7 @@ message Predictions {
 
     // Class of database.
     string db_class = 7;
+
+    // Keyword arguments to pass to the database constructor.
+    repeated KeyVal db_kwargs = 8;
 }

--- a/acton/proto/predictors.proto
+++ b/acton/proto/predictors.proto
@@ -44,6 +44,9 @@ message Labels {
 
     // Class of database.
     string db_class = 6;
+
+    // Keyword arguments to pass to the database constructor.
+    repeated KeyVal db_kwargs = 7;
 }
 
 /**

--- a/acton/proto/predictors_pb2.py
+++ b/acton/proto/predictors_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='predictors.proto',
   package='acton.predictors',
   syntax='proto3',
-  serialized_pb=_b('\n\x10predictors.proto\x12\x10\x61\x63ton.predictors\"$\n\x06KeyVal\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xd7\x01\n\x06Labels\x12;\n\x08instance\x18\x01 \x03(\x0b\x32).acton.predictors.Labels.LabelledInstance\x12\x13\n\x0bn_labellers\x18\x02 \x01(\x05\x12\x1a\n\x12n_label_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x05 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x06 \x01(\t\x1a-\n\x10LabelledInstance\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05label\x18\x02 \x03(\x01\"\xa2\x02\n\x0bPredictions\x12<\n\nprediction\x18\x01 \x03(\x0b\x32(.acton.predictors.Predictions.Prediction\x12\x14\n\x0cn_predictors\x18\x02 \x01(\x05\x12\x1f\n\x17n_prediction_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x11\n\tpredictor\x18\x05 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x06 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x07 \x01(\t\x12+\n\tdb_kwargs\x18\x08 \x03(\x0b\x32\x18.acton.predictors.KeyVal\x1a,\n\nPrediction\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\nprediction\x18\x02 \x03(\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x10predictors.proto\x12\x10\x61\x63ton.predictors\"$\n\x06KeyVal\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x84\x02\n\x06Labels\x12;\n\x08instance\x18\x01 \x03(\x0b\x32).acton.predictors.Labels.LabelledInstance\x12\x13\n\x0bn_labellers\x18\x02 \x01(\x05\x12\x1a\n\x12n_label_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x05 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x06 \x01(\t\x12+\n\tdb_kwargs\x18\x07 \x03(\x0b\x32\x18.acton.predictors.KeyVal\x1a-\n\x10LabelledInstance\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05label\x18\x02 \x03(\x01\"\xa2\x02\n\x0bPredictions\x12<\n\nprediction\x18\x01 \x03(\x0b\x32(.acton.predictors.Predictions.Prediction\x12\x14\n\x0cn_predictors\x18\x02 \x01(\x05\x12\x1f\n\x17n_prediction_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x11\n\tpredictor\x18\x05 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x06 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x07 \x01(\t\x12+\n\tdb_kwargs\x18\x08 \x03(\x0b\x32\x18.acton.predictors.KeyVal\x1a,\n\nPrediction\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\nprediction\x18\x02 \x03(\x01\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -97,8 +97,8 @@ _LABELS_LABELLEDINSTANCE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=247,
-  serialized_end=292,
+  serialized_start=292,
+  serialized_end=337,
 )
 
 _LABELS = _descriptor.Descriptor(
@@ -150,6 +150,13 @@ _LABELS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='db_kwargs', full_name='acton.predictors.Labels.db_kwargs', index=6,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -163,7 +170,7 @@ _LABELS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=77,
-  serialized_end=292,
+  serialized_end=337,
 )
 
 
@@ -200,8 +207,8 @@ _PREDICTIONS_PREDICTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=541,
-  serialized_end=585,
+  serialized_start=586,
+  serialized_end=630,
 )
 
 _PREDICTIONS = _descriptor.Descriptor(
@@ -279,12 +286,13 @@ _PREDICTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=295,
-  serialized_end=585,
+  serialized_start=340,
+  serialized_end=630,
 )
 
 _LABELS_LABELLEDINSTANCE.containing_type = _LABELS
 _LABELS.fields_by_name['instance'].message_type = _LABELS_LABELLEDINSTANCE
+_LABELS.fields_by_name['db_kwargs'].message_type = _KEYVAL
 _PREDICTIONS_PREDICTION.containing_type = _PREDICTIONS
 _PREDICTIONS.fields_by_name['prediction'].message_type = _PREDICTIONS_PREDICTION
 _PREDICTIONS.fields_by_name['db_kwargs'].message_type = _KEYVAL

--- a/acton/proto/predictors_pb2.py
+++ b/acton/proto/predictors_pb2.py
@@ -19,11 +19,49 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='predictors.proto',
   package='acton.predictors',
   syntax='proto3',
-  serialized_pb=_b('\n\x10predictors.proto\x12\x10\x61\x63ton.predictors\"\xd7\x01\n\x06Labels\x12;\n\x08instance\x18\x01 \x03(\x0b\x32).acton.predictors.Labels.LabelledInstance\x12\x13\n\x0bn_labellers\x18\x02 \x01(\x05\x12\x1a\n\x12n_label_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x05 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x06 \x01(\t\x1a-\n\x10LabelledInstance\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05label\x18\x02 \x03(\x01\"\xf5\x01\n\x0bPredictions\x12<\n\nprediction\x18\x01 \x03(\x0b\x32(.acton.predictors.Predictions.Prediction\x12\x14\n\x0cn_predictors\x18\x02 \x01(\x05\x12\x1f\n\x17n_prediction_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x11\n\tpredictor\x18\x05 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x06 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x07 \x01(\t\x1a,\n\nPrediction\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\nprediction\x18\x02 \x03(\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x10predictors.proto\x12\x10\x61\x63ton.predictors\"$\n\x06KeyVal\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xd7\x01\n\x06Labels\x12;\n\x08instance\x18\x01 \x03(\x0b\x32).acton.predictors.Labels.LabelledInstance\x12\x13\n\x0bn_labellers\x18\x02 \x01(\x05\x12\x1a\n\x12n_label_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x05 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x06 \x01(\t\x1a-\n\x10LabelledInstance\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05label\x18\x02 \x03(\x01\"\xa2\x02\n\x0bPredictions\x12<\n\nprediction\x18\x01 \x03(\x0b\x32(.acton.predictors.Predictions.Prediction\x12\x14\n\x0cn_predictors\x18\x02 \x01(\x05\x12\x1f\n\x17n_prediction_dimensions\x18\x03 \x01(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x11\n\tpredictor\x18\x05 \x01(\t\x12\x0f\n\x07\x64\x62_path\x18\x06 \x01(\t\x12\x10\n\x08\x64\x62_class\x18\x07 \x01(\t\x12+\n\tdb_kwargs\x18\x08 \x03(\x0b\x32\x18.acton.predictors.KeyVal\x1a,\n\nPrediction\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\nprediction\x18\x02 \x03(\x01\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
+
+
+_KEYVAL = _descriptor.Descriptor(
+  name='KeyVal',
+  full_name='acton.predictors.KeyVal',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='acton.predictors.KeyVal.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='acton.predictors.KeyVal.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=38,
+  serialized_end=74,
+)
 
 
 _LABELS_LABELLEDINSTANCE = _descriptor.Descriptor(
@@ -59,8 +97,8 @@ _LABELS_LABELLEDINSTANCE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=209,
-  serialized_end=254,
+  serialized_start=247,
+  serialized_end=292,
 )
 
 _LABELS = _descriptor.Descriptor(
@@ -124,8 +162,8 @@ _LABELS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=39,
-  serialized_end=254,
+  serialized_start=77,
+  serialized_end=292,
 )
 
 
@@ -162,8 +200,8 @@ _PREDICTIONS_PREDICTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=458,
-  serialized_end=502,
+  serialized_start=541,
+  serialized_end=585,
 )
 
 _PREDICTIONS = _descriptor.Descriptor(
@@ -222,6 +260,13 @@ _PREDICTIONS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='db_kwargs', full_name='acton.predictors.Predictions.db_kwargs', index=7,
+      number=8, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -234,16 +279,25 @@ _PREDICTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=257,
-  serialized_end=502,
+  serialized_start=295,
+  serialized_end=585,
 )
 
 _LABELS_LABELLEDINSTANCE.containing_type = _LABELS
 _LABELS.fields_by_name['instance'].message_type = _LABELS_LABELLEDINSTANCE
 _PREDICTIONS_PREDICTION.containing_type = _PREDICTIONS
 _PREDICTIONS.fields_by_name['prediction'].message_type = _PREDICTIONS_PREDICTION
+_PREDICTIONS.fields_by_name['db_kwargs'].message_type = _KEYVAL
+DESCRIPTOR.message_types_by_name['KeyVal'] = _KEYVAL
 DESCRIPTOR.message_types_by_name['Labels'] = _LABELS
 DESCRIPTOR.message_types_by_name['Predictions'] = _PREDICTIONS
+
+KeyVal = _reflection.GeneratedProtocolMessageType('KeyVal', (_message.Message,), dict(
+  DESCRIPTOR = _KEYVAL,
+  __module__ = 'predictors_pb2'
+  # @@protoc_insertion_point(class_scope:acton.predictors.KeyVal)
+  ))
+_sym_db.RegisterMessage(KeyVal)
 
 Labels = _reflection.GeneratedProtocolMessageType('Labels', (_message.Message,), dict(
 

--- a/acton/proto/wrappers.py
+++ b/acton/proto/wrappers.py
@@ -33,7 +33,8 @@ class PredictorInput(object):
             else:
                 raise TypeError('proto should be str or protobuf.')
         self._validate_proto()
-        self.db_kwargs = {kwa.key: kwa.value for kwa in self.proto.db_kwargs}
+        self.db_kwargs = {kwa.key: json.loads(kwa.value)
+                          for kwa in self.proto.db_kwargs}
         self._set_default()
 
     @property

--- a/acton/proto/wrappers.py
+++ b/acton/proto/wrappers.py
@@ -1,6 +1,6 @@
 """Classes that wrap protobufs."""
 
-from typing import Union, List
+from typing import Union, List, Iterable
 
 import acton.database
 import acton.proto.predictors_pb2 as predictors_pb
@@ -32,6 +32,7 @@ class PredictorInput(object):
             else:
                 raise TypeError('proto should be str or protobuf.')
         self._validate_proto()
+        self._set_default()
 
     @property
     def DB(self) -> acton.database.Database:
@@ -140,3 +141,135 @@ class PredictorInput(object):
     def _set_default(self):
         """Adds default parameters to the protobuf."""
         self.proto.dtype = self.proto.dtype or 'float32'
+
+
+class PredictorOutput(object):
+    """Wrapper for the predictor output protobuf.
+
+    Attributes
+    ----------
+    proto : predictors_pb.Predictions
+        Protobuf representing the output.
+    """
+
+    def __init__(self, proto: Union[str, predictors_pb.Predictions]):
+        """
+        Parameters
+        ----------
+        proto
+            Path to .proto file, or raw protobuf itself.
+        """
+        try:
+            self.proto = acton.proto.io.read_proto(
+                proto, predictors_pb.Predictions)
+        except TypeError:
+            if isinstance(proto, predictors_pb.Predictions):
+                self.proto = proto
+            else:
+                raise TypeError('proto should be str or protobuf.')
+        self._validate_proto()
+        self._set_default()
+
+    @property
+    def DB(self) -> acton.database.Database:
+        """Gets a database context manager for the specified database.
+
+        Returns
+        -------
+        type
+            Database context manager.
+        """
+        if hasattr(self, '_DB'):
+            return self._DB
+
+        self._DB = lambda: acton.database.DATABASES[self.proto.db_class](
+            self.proto.db_path, label_dtype=self.proto.dtype)
+
+        return self._DB
+
+    @property
+    def ids(self) -> List[bytes]:
+        """Gets a list of IDs.
+
+        Returns
+        -------
+        List[bytes]
+            List of known IDs.
+        """
+        if hasattr(self, '_ids'):
+            return self._ids
+
+        self._ids = [prediction.id for prediction in self.proto.prediction]
+        return self._ids
+
+    @property
+    def predictions(self) -> numpy.ndarray:
+        """Gets predictions array specified in input.
+
+        Notes
+        -----
+        The returned array is cached by this object so future calls will not
+        need to recompile the array.
+
+        Returns
+        -------
+        numpy.ndarray
+            T x N x D NumPy array of predictions.
+        """
+        if hasattr(self, '_predictions'):
+            return self._predictions
+
+        self._predictions = []
+        for prediction in self.proto.prediction:
+            data = prediction.label
+            shape = (self.proto.n_predictors,
+                     self.proto.n_prediction_dimensions)
+            dtype = self.proto.dtype
+            self._predictions.append(
+                acton.proto.io.get_ndarray(data, shape, dtype))
+        self._predictions = numpy.array(self._predictions).transpose((1, 0, 2))
+        return self._predictions
+
+    def _validate_proto(self):
+        """Checks that the protobuf is valid and enforces constraints.
+
+        Raises
+        ------
+        ValueError
+        """
+        if self.proto.db_class not in acton.database.DATABASES:
+            raise ValueError('Invalid database class: {}'.format(
+                self.proto.db_class))
+
+        if self.proto.n_predictors < 1:
+            raise ValueError('Number of predictors must be > 0.')
+
+        if self.proto.n_prediction_dimensions < 1:
+            raise ValueError('Prediction dimension must be > 0.')
+
+        if not self.proto.db_path:
+            raise ValueError('Must specify db_path.')
+
+    def _set_default(self):
+        """Adds default parameters to the protobuf."""
+        self.proto.dtype = self.proto.dtype or 'float32'
+
+
+def from_predictions(
+        ids: Iterable[bytes],
+        predictions: numpy.ndarray) -> PredictorOutput:
+    """Converts NumPy predictions to a PredictorOutput.
+
+    Parameters
+    ----------
+    ids
+        Iterable of instance IDs.
+    predictions
+        T x N x D array of corresponding predictions.
+
+    Returns
+    -------
+    PredictorOutput
+    """
+    raise NotImplementedError()
+

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -58,10 +58,9 @@ class TestPredictorInput(unittest.TestCase):
     def test_features(self):
         """PredictorInput gives a features array."""
         # Setup mock.
-        for DB in acton.database.DATABASES:
-            DB = acton.database.DATABASES[DB]
-            db = DB().__enter__.return_value
-            db.read_features.return_value = self.features
+        DB = acton.database.DATABASES['ManagedHDF5Database']
+        db = DB().__enter__.return_value
+        db.read_features.return_value = self.features
 
         predictor_input = acton.proto.wrappers.PredictorInput(self.path)
         self.assertTrue(numpy.allclose(

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -8,7 +8,6 @@ Tests for `predictors` module.
 """
 
 import os.path
-import sys
 import tempfile
 import unittest
 import unittest.mock

--- a/tests/test_proto_io.py
+++ b/tests/test_proto_io.py
@@ -8,8 +8,8 @@ Tests for `proto.io` module.
 """
 
 import os.path
-import sys
 import tempfile
+from typing import List
 import unittest
 import unittest.mock
 
@@ -36,18 +36,32 @@ class TestIOMany(unittest.TestCase):
     def tearDown(self):
         self.tempdir.cleanup()
 
+    @staticmethod
+    def make_protobufs(n: int=10) -> List[bytes]:
+        """Makes random-length "protobufs".
+
+        Parameters
+        ----------
+        n
+            Number of protobufs.
+
+        Yields
+        ------
+        bytes
+            A random protobuf.
+        """
+        for _ in range(n):
+            protobuf = bytes(
+                numpy.random.randint(256)
+                for _ in range(numpy.random.randint(100)))
+            yield protobuf
+
     def test_write_read(self):
         """Protobufs written by write_protos can be read by read_protos."""
         # We will assume that the write/read functions are using the
         # serialisation methods built-in to protobufs. We thus deal only with
         # serialised protobufs.
-        serialised_protos = []
-        # Make some random-length "protobufs".
-        for _ in range(10):
-            protobuf = bytes(
-                numpy.random.randint(256)
-                for _ in range(numpy.random.randint(100)))
-            serialised_protos.append(protobuf)
+        serialised_protos = list(self.make_protobufs())
 
         # Write the protobufs.
         writer = acton.proto.io.write_protos(self.path)
@@ -61,3 +75,24 @@ class TestIOMany(unittest.TestCase):
         read_protobufs = [i.proto
             for i in acton.proto.io.read_protos(self.path, self.Proto)]
         self.assertEqual(serialised_protos, read_protobufs)
+
+    def test_write_read_file(self):
+        """read_protos accepts opened binary files."""
+        # This function is identical to test_write_read but with files instead
+        # of paths.
+
+        serialised_protos = list(self.make_protobufs())
+
+        # Write the protobufs.
+        writer = acton.proto.io.write_protos(self.path)
+        next(writer)
+        for protobuf in serialised_protos:
+            self.proto.SerializeToString.return_value = protobuf
+            writer.send(self.proto)
+        writer.send(None)
+
+        # Read the protobufs using a file object.
+        with open(self.path, 'rb') as proto_file:
+            read_protobufs = [i.proto for i in acton.proto.io.read_protos(
+                proto_file, self.Proto)]
+            self.assertEqual(serialised_protos, read_protobufs)

--- a/tests/test_proto_io.py
+++ b/tests/test_proto_io.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+"""
+test_proto_io
+----------------------------------
+
+Tests for `proto.io` module.
+"""
+
+import os.path
+import sys
+import tempfile
+import unittest
+import unittest.mock
+
+import acton.proto.io
+import numpy
+
+
+class TestIOMany(unittest.TestCase):
+    """Tests read_protos and write_protos."""
+
+    def setUp(self):
+        # Make some (mock) protobufs.
+        self.proto = unittest.mock.Mock(['SerializeToString'])
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tempdir.name, 'testiomany.proto')
+        # And a mock class for deserialisation.
+        class Proto:
+            def ParseFromString(self, string):
+                self.proto = string
+        self.Proto = Proto
+        # The idea here is to store the serialised protobuf, so we can check
+        # that it has been read in correctly.
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_write_read(self):
+        """Protobufs written by write_protos can be read by read_protos."""
+        # We will assume that the write/read functions are using the
+        # serialisation methods built-in to protobufs. We thus deal only with
+        # serialised protobufs.
+        serialised_protos = []
+        # Make some random-length "protobufs".
+        for _ in range(10):
+            protobuf = bytes(
+                numpy.random.randint(256)
+                for _ in range(numpy.random.randint(100)))
+            serialised_protos.append(protobuf)
+
+        # Write the protobufs.
+        writer = acton.proto.io.write_protos(self.path)
+        next(writer)
+        for protobuf in serialised_protos:
+            self.proto.SerializeToString.return_value = protobuf
+            writer.send(self.proto)
+        writer.send(None)
+
+        # Read the protobufs.
+        read_protobufs = [i.proto
+            for i in acton.proto.io.read_protos(self.path, self.Proto)]
+        self.assertEqual(serialised_protos, read_protobufs)


### PR DESCRIPTION
- Adds a `PredictorOutput` wrapper class and a function to easily create instances of it.
- Adds code for serialising and storing delimited protobufs.
- Adds an `ASCIIReader` to encapsulate logic of reading ASCII files in a reproducible way.
- Adds a `db_kwargs` section to the predictor output protobuf for storing database setup arguments.
- Adds a `plot` script to demonstrate plotting from stored predictions.
- Miscellaneous fixes for the main script.