### PR TITLE
Fix dependency issues and acton.proto downloading problem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,6 @@ Dependencies
 Most dependencies will be installed by pip. You will need to manually install:
 
 - Python 3.4+
-- `Protobuf <https://github.com/google/protobuf/tree/master/python>`_
 
 Setup
 -----

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ requirements = [
 	'tables>=3.3.0',
 	'sphinx_rtd_theme==0.1.9',
 	'mock==2.0.0',
-	'GPy>=1.5.6',
+	'GPy == 1.9.2',
 	'matplotlib==2.0.0',
-	'paramz==0.7.4'
+	#'paramz==0.7.4'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ requirements = [
 	'mock==2.0.0',
 	'GPy>=1.5.6',
 	'matplotlib==2.0.0',
+	'paramz==0.7.4'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
 	'coverage==4.1',
 	'Sphinx==1.4.8',
 	'numpydoc==0.6.0',
-	'pyflakes>=1.3.0',
+	'pyflakes<1.4.0,>=1.3.0',
 	'pandas>=0.15.2',
 	'nose==1.3.7',
 	'click==6.6',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements = [
 	'tables>=3.3.0',
 	'sphinx_rtd_theme==0.1.9',
 	'mock==2.0.0',
-	'GPy == 1.9.2',
+	'GPy',
 	'matplotlib==2.0.0',
 	#'paramz==0.7.4'
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,30 @@ with open('README.rst') as readme_file:
 #     history = history_file.read()
 
 requirements = [
+	'h5py>=2.6.0',
+	'protobuf>=3.1.0',
+	'numpy>=1.11.0',
+	'scipy>=0.17.0',
+	'scikit-learn>=0.18.1',
+	'typing>=3.5.2',
+	'astropy>=1.1.2',
+	'pip>=8.1.2',
+	'bumpversion==0.5.3',
+	'wheel==0.29.0',
+	'watchdog==0.8.3',
+	'flake8==3.2.0',
+	'coverage==4.1',
+	'Sphinx==1.4.8',
+	'numpydoc==0.6.0',
+	'pyflakes>=1.3.0',
+	'pandas>=0.15.2',
+	'nose==1.3.7',
+	'click==6.6',
+	'tables>=3.3.0',
+	'sphinx_rtd_theme==0.1.9',
+	'mock==2.0.0',
+	'GPy>=1.5.6',
+	'matplotlib==2.0.0',
 ]
 
 test_requirements = [
@@ -31,9 +55,10 @@ setup(
     author_email='chengsoon.ong@anu.edu.au',
     packages=[
         'acton',
+	'acton.proto',
     ],
-    package_dir={'acton':
-                 'acton'},
+    #package_dir={'acton':
+    #             'acton'},
     entry_points={
         'console_scripts': [
             'acton=acton.cli:main',


### PR DESCRIPTION
Now the dependent packages can be directly downloaded by pip install.
Fixed the NoMoudleError (no acton.proto module)